### PR TITLE
Add meta main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,15 @@
+---
+dependencies: []
+
+galaxy_info:
+  author: STO Trust
+  description: Scylla installation and configuration for Linux.
+  company: "Cisco"
+  license: "license (BSD, MIT)"
+  min_ansible_version: 2.7
+  platforms:
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - scylla


### PR DESCRIPTION
The meta/main.yml file is required for ansible galaxy, oversight on setting up the repo.  Without it you will get the following on install:

[WARNING]: - ansible-scylla was NOT installed successfully: this role does not appear to have a meta/main.yml file.


